### PR TITLE
Bug Fix for issue #2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ def init(
         if 'debian' in platform.dist():
             try:
                 import stdeb
-            except ImportError, e:
+            except ImportError as e:
                 pass
 
     return setup


### PR DESCRIPTION
Fix for Issue #2. 

"except ImportError, e:" was deprecated in Python 2.7 and removed completely in Python 3.x. Nowadays the syntax is: "except ImportError as e:".

This has been amended.

Thanks.
